### PR TITLE
Add option to keep existing avds

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ java -jar swarmer.jar start …
   * Timeout to wait for emulator to finish boot. Default value is 180 seconds.
 * `--redirect-logcat-to`
   * Path either relative or absolute to the file that will be used to redirect logcat of started emulator to. No redirection will happen if parameter is not presented.
+* `--keep-existing-avds`
+  * Avoid recreating avds and reuse existing ones whenever possible.
 
 ##### Examples
 

--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Args.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Args.kt
@@ -119,9 +119,17 @@ sealed class Commands {
                     names = ["--use-compat-emulator"],
                     required = false,
                     description = "Use old compat emulator tool. Look https://issuetracker.google.com/issues/66886035 for details. False by default.",
-                    order = 10
+                    order = 11
             )
-            var useCompatEmulator: Boolean = false
+            var useCompatEmulator: Boolean = false,
+
+            @Parameter(
+                    names = ["--keep-existing-avds"],
+                    required = false,
+                    description = "Don't recreate avds if one with the same name already exists.",
+                    order = 12
+            )
+            var keepExistingAvds: Boolean = false
 
     ) : Commands()
 

--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -194,20 +194,29 @@ private fun createAvd(args: Commands.Start): Observable<Unit> {
 
     val startTime = AtomicLong()
 
-    return if (args.keepExistingAvds && File("$home/.android/avd/${args.emulatorName}.avd").exists()) {
-        Observable
-                .just(Unit)
-                .doOnSubscribe { log("Avd ${args.emulatorName} already exists, will not be overridden.") }
+    val createAvd = Observable
+            .merge(iDontWishToCreateCustomHardwareProfile, createAvdProcess)
+            .first { it is Notification.Exit }
+            .doOnError { log("Error during creation of avd ${args.emulatorName}, error = $it") }
+            .retry(3) // https://code.google.com/p/android/issues/detail?id=262719
+            .map { Unit }
+            .doOnSubscribe { log("Creating avd ${args.emulatorName}."); startTime.set(nanoTime()) }
+            .doOnNext { log("Avd ${args.emulatorName} created in ${(nanoTime() - startTime.get()).nanosAsSeconds()} seconds.") }
+            .doOnError { log("Could not create avd ${args.emulatorName}, error = $it") }
+
+    return if (args.keepExistingAvds) {
+        createdEmulators(args).flatMapObservable {
+            if (it.contains(args.emulatorName)) {
+                Observable
+                        .just(Unit)
+                        .doOnSubscribe { log("Avd ${args.emulatorName} already exists, will not be overridden.") }
+            } else {
+                createAvd
+            }
+        }
+
     } else {
-        Observable
-                .merge(iDontWishToCreateCustomHardwareProfile, createAvdProcess)
-                .first { it is Notification.Exit }
-                .doOnError { log("Error during creation of avd ${args.emulatorName}, error = $it") }
-                .retry(3) // https://code.google.com/p/android/issues/detail?id=262719
-                .map { Unit }
-                .doOnSubscribe { log("Creating avd ${args.emulatorName}."); startTime.set(nanoTime()) }
-                .doOnNext { log("Avd ${args.emulatorName} created in ${(nanoTime() - startTime.get()).nanosAsSeconds()} seconds.") }
-                .doOnError { log("Could not create avd ${args.emulatorName}, error = $it") }
+        createAvd
     }
 }
 
@@ -340,3 +349,17 @@ private fun outputDirectory(args: Commands.Start) =
 
 private fun connectedEmulators(): Single<Set<AdbDevice>> =
         connectedAdbDevices().take(1).toSingle().map { it.filter { it.isEmulator }.toSet() }
+
+private fun createdEmulators(args: Commands.Start, timeout: Pair<Int, TimeUnit> = 60 to SECONDS): Single<Set<String>> =
+        process(
+                commandAndArgs = listOf(emulatorBinary(args), "-list-avds"),
+                timeout = timeout,
+                unbufferedOutput = true
+        ).ofType(Notification.Exit::class.java)
+                .toSingle()
+                .map {
+                    it.output.readText()
+                            .split(System.lineSeparator())
+                            .filter { !it.isBlank() }
+                            .toSet()
+                }

--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -214,7 +214,6 @@ private fun createAvd(args: Commands.Start): Observable<Unit> {
                 createAvd
             }
         }
-
     } else {
         createAvd
     }
@@ -361,5 +360,6 @@ private fun createdEmulators(args: Commands.Start, timeout: Pair<Int, TimeUnit> 
                     it.output.readText()
                             .split(System.lineSeparator())
                             .filter { !it.isBlank() }
+                            .map { it.trim() }
                             .toSet()
                 }

--- a/swarmer/src/test/kotlin/com/gojuno/swarmer/ArgsSpec.kt
+++ b/swarmer/src/test/kotlin/com/gojuno/swarmer/ArgsSpec.kt
@@ -18,7 +18,8 @@ class ArgsSpec : Spek({
             "--emulator-start-options", "-prop option=value",
             "--emulator-start-timeout-seconds", "180",
             "--redirect-logcat-to", "logcat.txt",
-            "--verbose-emulator", "--keep-output-on-exit"
+            "--verbose-emulator", "--keep-output-on-exit",
+            "--keep-existing-avds"
     )
 
     on("parse args with only required fields") {
@@ -53,7 +54,8 @@ class ArgsSpec : Spek({
                     emulatorStartTimeoutSeconds = 180L,
                     redirectLogcatTo = "logcat.txt",
                     verbose = true,
-                    keepOutputOnExit = true
+                    keepOutputOnExit = true,
+                    keepExistingAvds = true
             )))
         }
     }


### PR DESCRIPTION
Closes #41 (@yunikkk, @artem-zinnatullin)

When starting 4 emulators on my development machine, this change cut the boot-up time of the emulators in half (from ~55 sec down to ~25 sec). When using snapshots, it went down even further (~12 sec).