### PR TITLE
Speed up emulator port allocation

### DIFF
--- a/swarmer/src/test/kotlin/com/gojuno/swarmer/EmulatorsSpec.kt
+++ b/swarmer/src/test/kotlin/com/gojuno/swarmer/EmulatorsSpec.kt
@@ -167,7 +167,7 @@ class EmulatorsSpec : Spek({
                     connectedAdbDevices = connectedAdbDevices,
                     createAvd = createAvd,
                     applyConfig = applyConfig,
-                    emulator = emulator,
+                    emulatorCmd = emulator,
                     startEmulatorProcess = startEmulatorsProcess,
                     waitForEmulatorToStart = waitForEmulatorToStart,
                     findAvailablePortsForNewEmulator = findAvailablePortsForNewEmulator,


### PR DESCRIPTION
Store a list of used ports so we don't need to wait for the emulator start command to finish before starting the next emulator.