### PR TITLE
Wait for dev.bootcomplete property on emulator launch

### DIFF
--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -310,7 +310,7 @@ private fun waitForEmulatorToFinishBoot(
                                     adb,
                                     "-s", emulator.id,
                                     "shell",
-                                    "getprop", "init.svc.bootanim"
+                                    "getprop", "dev.bootcomplete"
                             ),
                             timeout = 10 to SECONDS,
                             redirectOutputTo = outputDirectory(args),
@@ -318,9 +318,9 @@ private fun waitForEmulatorToFinishBoot(
                     )
                             .filter { it is Notification.Exit }
                             .cast(Notification.Exit::class.java)
-                            .map { it.output.readText().contains("stopped", ignoreCase = true) }
-                            .switchMap { bootAnimationStopped ->
-                                if (bootAnimationStopped) {
+                            .map { it.output.readText().contains("1", ignoreCase = true) }
+                            .switchMap { bootCompleted ->
+                                if (bootCompleted) {
                                     Observable.just(targetEmulator)
                                 } else {
                                     Observable.never()


### PR DESCRIPTION
Pull `dev.bootcomplete` instead of `init.svc.bootanim` system property to allow `-no-boot-anim` emulator start option.

From documentation: https://developer.android.com/studio/run/emulator-commandline#startup-options

> -no-boot-anim 
> Disable the boot animation during emulator startup for faster booting. On slower computers, this option can significantly speed up the boot sequence.

Who doesn't want faster booting? It also looks like AndroidStudio is using this property as well https://android.googlesource.com/platform/tools/adt/idea/+/studio-master-dev/android/src/com/android/tools/idea/avdmanager/EmulatorConnectionListener.java#142

I'm not too familiar with `swarmer` internals or RxJava. But at my sandbox repo `dev.bootcomplete` is available on all x86 emulators api15-28 https://travis-ci.org/plastiv/peta-androidsdk/builds/502602101

I can work on integrating CI for `swarmer` separately if you are interested. 

